### PR TITLE
Update from json method #20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsmodels",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "An implementation of models for TypeScript",
   "main": "package/index.js",
   "typings": "package/index.d.ts",

--- a/package/application-model.d.ts
+++ b/package/application-model.d.ts
@@ -6,17 +6,15 @@ export declare abstract class Model {
      * Converter of backend data to model format by aliases
      *
      * @param value - data from backend
-     * @param {boolean} shouldUpdateAll - do we need to make update for all variables or only for not defined?
      * @public
      */
-    _fromJSON(value: any, shouldUpdateAll?: boolean): void;
+    _fromJSON(value: any): void;
     /**
      *
      * @param value - data from backend
-     * @param {boolean} shouldUpdateAll - do we need to make update for all variables or only for not defined?
      * @private
      */
-    _updateFromJSON(value: any, shouldUpdateAll?: boolean): void;
+    _updateFromJSON(value: any): void;
     /**
      * Converter of model format to backend data by aliases
      *
@@ -26,7 +24,7 @@ export declare abstract class Model {
     _toJSON(): {};
     private _createObject(item, obj);
     private _isObject(item);
-    private _createItem(value, item, shouldUpdateAll?);
+    private _createItem(value, item);
 }
 /**
  * @deprecated Use the `AppModel` instead. Will be remove in version 1.0.0

--- a/package/application-model.d.ts
+++ b/package/application-model.d.ts
@@ -5,10 +5,18 @@ export declare abstract class Model {
     /**
      * Converter of backend data to model format by aliases
      *
-     * @param value data from backend
+     * @param value - data from backend
+     * @param {boolean} shouldUpdateAll - do we need to make update for all variables or only for not defined?
      * @public
      */
-    _fromJSON(value: any): void;
+    _fromJSON(value: any, shouldUpdateAll?: boolean): void;
+    /**
+     *
+     * @param value - data from backend
+     * @param {boolean} shouldUpdateAll - do we need to make update for all variables or only for not defined?
+     * @private
+     */
+    _updateFromJSON(value: any, shouldUpdateAll?: boolean): void;
     /**
      * Converter of model format to backend data by aliases
      *
@@ -18,6 +26,7 @@ export declare abstract class Model {
     _toJSON(): {};
     private _createObject(item, obj);
     private _isObject(item);
+    private _createItem(value, item, shouldUpdateAll?);
 }
 /**
  * @deprecated Use the `AppModel` instead. Will be remove in version 1.0.0

--- a/package/index.js
+++ b/package/index.js
@@ -127,30 +127,26 @@ var Model = /** @class */ (function () {
      * Converter of backend data to model format by aliases
      *
      * @param value - data from backend
-     * @param {boolean} shouldUpdateAll - do we need to make update for all variables or only for not defined?
      * @public
      */
-    Model.prototype._fromJSON = function (value, shouldUpdateAll) {
+    Model.prototype._fromJSON = function (value) {
         var _this = this;
-        if (shouldUpdateAll === void 0) { shouldUpdateAll = true; }
         Object.keys(this.constructor['_alias'])
             .forEach(function (key) {
-            _this._createItem(value, _this.constructor['_alias'][key], shouldUpdateAll);
+            _this._createItem(value, _this.constructor['_alias'][key]);
         });
     };
     /**
      *
      * @param value - data from backend
-     * @param {boolean} shouldUpdateAll - do we need to make update for all variables or only for not defined?
      * @private
      */
-    Model.prototype._updateFromJSON = function (value, shouldUpdateAll) {
+    Model.prototype._updateFromJSON = function (value) {
         var _this = this;
-        if (shouldUpdateAll === void 0) { shouldUpdateAll = true; }
         Object.keys(value).forEach(function (key) {
             var item = _this.constructor['_alias'][key];
             if (item) {
-                _this._createItem(value, item, shouldUpdateAll);
+                _this._createItem(value, item);
             }
         });
     };
@@ -188,13 +184,9 @@ var Model = /** @class */ (function () {
     Model.prototype._isObject = function (item) {
         return Object.prototype.toString.call(item) === '[object Object]';
     };
-    Model.prototype._createItem = function (value, item, shouldUpdateAll) {
+    Model.prototype._createItem = function (value, item) {
         var _this = this;
-        if (shouldUpdateAll === void 0) { shouldUpdateAll = true; }
         var newValue = value[item['value']];
-        if (!shouldUpdateAll && this[item['key']] !== void 0) {
-            return;
-        }
         if (item['type']) {
             if (Array.isArray(newValue)) {
                 this[item['key']] = newValue.map(function (x) { return _this._createObject(item, x); });

--- a/src/alias.decorator.ts
+++ b/src/alias.decorator.ts
@@ -3,11 +3,16 @@ import { Type } from './type';
 
 export function Alias<T extends Model>(alias?: string, type?: Type<T>) {
   return function (target: Object, propertyKey: string | symbol) {
-    target.constructor['_alias'] = target['constructor']['_alias'] || [];
-    target.constructor['_alias'].push({
-      key: propertyKey,
-      value: alias || propertyKey,
-      type: type
-    });
+    target.constructor['_alias'] = target['constructor']['_alias'] || {};
+
+    const value = alias || propertyKey;
+
+    if (!target.constructor['_alias'][value]) {
+      target.constructor['_alias'][value] = {
+        key: propertyKey,
+        value: value,
+        type: type
+      };
+    }
   };
 }

--- a/src/application-model.ts
+++ b/src/application-model.ts
@@ -7,14 +7,13 @@ export abstract class Model {
    * Converter of backend data to model format by aliases
    *
    * @param value - data from backend
-   * @param {boolean} shouldUpdateAll - do we need to make update for all variables or only for not defined?
    * @public
    */
-  public _fromJSON(value, shouldUpdateAll = true) {
+  public _fromJSON(value) {
     Object.keys(this.constructor['_alias'])
       .forEach(
         key => {
-          this._createItem(value, this.constructor['_alias'][key], shouldUpdateAll);
+          this._createItem(value, this.constructor['_alias'][key]);
         }
       );
   }
@@ -22,14 +21,13 @@ export abstract class Model {
   /**
    *
    * @param value - data from backend
-   * @param {boolean} shouldUpdateAll - do we need to make update for all variables or only for not defined?
    * @private
    */
-  public _updateFromJSON(value, shouldUpdateAll = true) {
+  public _updateFromJSON(value) {
     Object.keys(value).forEach((key) => {
       const item = this.constructor['_alias'][key];
       if (item) {
-        this._createItem(value, item, shouldUpdateAll);
+        this._createItem(value, item);
       }
     })
   }
@@ -72,10 +70,8 @@ export abstract class Model {
     return Object.prototype.toString.call(item) === '[object Object]';
   }
 
-  private _createItem(value, item, shouldUpdateAll = true) {
+  private _createItem(value, item) {
     const newValue = value[item['value']];
-
-    if (!shouldUpdateAll && this[item['key']] !== void 0) { return; }
 
     if (item['type']) {
       if (Array.isArray(newValue)) {

--- a/src/application-model.ts
+++ b/src/application-model.ts
@@ -6,26 +6,32 @@ export abstract class Model {
   /**
    * Converter of backend data to model format by aliases
    *
-   * @param value data from backend
+   * @param value - data from backend
+   * @param {boolean} shouldUpdateAll - do we need to make update for all variables or only for not defined?
    * @public
    */
-  public _fromJSON(value) {
-    this.constructor['_alias']
+  public _fromJSON(value, shouldUpdateAll = true) {
+    Object.keys(this.constructor['_alias'])
       .forEach(
-        item => {
-          const newValue = value[item['value']];
-
-          if (item['type']) {
-            if (Array.isArray(newValue)) {
-              this[item['key']] = newValue.map(x => this._createObject(item, x));
-            } else if (this._isObject(newValue)) {
-              this[item['key']] = this._createObject(item, newValue);
-            }
-          } else {
-            this[item['key']] = value[item['value']];
-          }
+        key => {
+          this._createItem(value, this.constructor['_alias'][key], shouldUpdateAll);
         }
       );
+  }
+
+  /**
+   *
+   * @param value - data from backend
+   * @param {boolean} shouldUpdateAll - do we need to make update for all variables or only for not defined?
+   * @private
+   */
+  public _updateFromJSON(value, shouldUpdateAll = true) {
+    Object.keys(value).forEach((key) => {
+      const item = this.constructor['_alias'][key];
+      if (item) {
+        this._createItem(value, item, shouldUpdateAll);
+      }
+    })
   }
 
   /**
@@ -64,6 +70,22 @@ export abstract class Model {
 
   private _isObject(item): boolean {
     return Object.prototype.toString.call(item) === '[object Object]';
+  }
+
+  private _createItem(value, item, shouldUpdateAll = true) {
+    const newValue = value[item['value']];
+
+    if (!shouldUpdateAll && this[item['key']] !== void 0) { return; }
+
+    if (item['type']) {
+      if (Array.isArray(newValue)) {
+        this[item['key']] = newValue.map(x => this._createObject(item, x));
+      } else if (this._isObject(newValue)) {
+        this[item['key']] = this._createObject(item, newValue);
+      }
+    } else {
+      this[item['key']] = value[item['value']];
+    }
   }
 }
 


### PR DESCRIPTION
Was implemented method updateFromJSON which was described in #20 

Also was changed alias decorator mechanism for storing decorated attrs (`constructor['_alias']`). From now I suggest to use Object instead of array where properties which came from the server will be stored as keys. It can help us to do fast check do we have some property in decorated properties or no. I've pumped minor version by this reason

Also was added new flag for `_fromJSON` and `_updateFromJSON` methods which calls `shouldUpdateAll`.

This flag `FALSE` by default. The main goal is to indicate that we want to upgrade only not defined properties.
